### PR TITLE
Add class option spec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,26 @@ Overview
 
 The default `sphinx.ext.autodoc <http://www.sphinx-doc.org/en/master/ext/autodoc.html>`_ module does not handle function groups with variants created by the `variants <https://github.com/python-variants/variants>`_ module correctly. This extension registers an automatic documenter that detects variant functions and methods and enables documentation of both the primary and variant functions.
 
+To use this with your project that uses ``variants``, first install this extension with ``pip`` (or, preferably, add this to the documentation dependencies):
+
+.. code-block::
+
+    pip install sphinx_autodoc_variants
+
+With this installed, add ``'sphinx_autodoc_variants'`` to the ``extensions`` variable of  your ``conf.py``, e.g.:
+
+.. code-block::
+
+    extensions = ['sphinx.ext.autodoc',
+                  'sphinx.ext.viewcode',
+                  'sphinx_autodoc_variants']
+
+
+This will enable proper documentation of ``variants`` functions under ``.. automodule`` or other `autodoc directives <http://www.sphinx-doc.org/en/master/ext/autodoc.html>`_.
+
+If you want to explicitly document a ``variants`` function group, use ``.. autoprimary_function`` for functions and ``.. autoprimary_method`` for methods.
+
+
 Links
 -----
 

--- a/src/sphinx_autodoc_variants/variant_autodoc.py
+++ b/src/sphinx_autodoc_variants/variant_autodoc.py
@@ -4,6 +4,7 @@ Provides the automatic documenter type for variants
 
 from sphinx.ext.autodoc import Documenter, ModuleDocumenter
 from sphinx.ext.autodoc import ModuleLevelDocumenter, ClassLevelDocumenter
+from sphinx.ext.autodoc import ClassDocumenter
 from sphinx.ext.autodoc import FunctionDocumenter, MethodDocumenter
 from sphinx.ext.autodoc import DocstringSignatureMixin
 from sphinx.util.inspect import Signature
@@ -19,6 +20,8 @@ if False:  # pragma: nocover
 
 
 class BasePrimaryDocumenter(Documenter, DocstringSignatureMixin):
+    option_spec = ClassDocumenter.option_spec
+
     def format_args(self):
         # type: () -> Text
         # for primary functions, the relevant signature is __main_form__
@@ -48,7 +51,8 @@ class VariantFunctionDocumenter(PrimaryFunctionDocumenter):
     objtype = 'variant_function'
     directivetype = 'function'
     is_method = False
-    priority = 15
+    priority = 14
+    option_spec = FunctionDocumenter.option_spec
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
@@ -75,7 +79,8 @@ class VariantMethodDocumenter(PrimaryMethodDocumenter):
     objtype = 'variant_method'
     directivetype = 'method'
     is_method = True
-    priority = 16
+    priority = 15
+    option_spec = MethodDocumenter.option_spec
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):


### PR DESCRIPTION
This gives the `Primary*Documenter` classes the `option_spec` from `ClassDocumenter`, so that the variant's `:member:`s can be shown.